### PR TITLE
Adjust bin dir for VSMac 17.0, bump version

### DIFF
--- a/VSMacLocator/VSMacInstance.cs
+++ b/VSMacLocator/VSMacInstance.cs
@@ -67,7 +67,7 @@ namespace VSMacLocator
                 var values = MacInterop.GetStringValuesFromPlist(infoPlistPath, bundleShortVersionKey, releaseIdKey);
                 var bundleVersion = values[bundleShortVersionKey];
                 var releaseId = values[releaseIdKey];
-                var binDir = Path.Combine(bundlePath, "Contents", "Resources", "lib", "monodevelop", "bin");
+                var binDir = Path.Combine(bundlePath, "Contents", "MonoBundle");
 
                 if ((bundleVersion is null) || (releaseId is null))
                 {

--- a/VSMacLocator/VSMacInstance.cs
+++ b/VSMacLocator/VSMacInstance.cs
@@ -67,14 +67,23 @@ namespace VSMacLocator
                 var values = MacInterop.GetStringValuesFromPlist(infoPlistPath, bundleShortVersionKey, releaseIdKey);
                 var bundleVersion = values[bundleShortVersionKey];
                 var releaseId = values[releaseIdKey];
-                var binDir = Path.Combine(bundlePath, "Contents", "MonoBundle");
 
                 if ((bundleVersion is null) || (releaseId is null))
                 {
                     return null;
                 }
 
+                // This is the path to the binaries in current versions of Visual Studio for Mac
+                var binDir = Path.Combine(bundlePath, "Contents", "MonoBundle");
                 var brandingFile = Path.Combine(binDir, "branding", "Branding.xml");
+                if (!File.Exists(brandingFile)) {
+                    // If the file isn't there, check the previous location for backward compatibility
+                    binDir = Path.Combine(bundlePath, "Contents", "Resources", "lib", "monodevelop", "bin");
+                    brandingFile = Path.Combine(binDir, "branding", "Branding.xml");
+                    if (!File.Exists(brandingFile)) {
+                        return null;
+                    }
+                }
                 isPreview ??= File.ReadLines(brandingFile).Any(l => l.IndexOf("Preview", System.StringComparison.Ordinal) > -1);
 
                 VSMacInstance instance = new VSMacInstance(bundlePath, binDir, bundleVersion, releaseId, isPreview.Value);

--- a/vsmac-cli/vsmac-cli.csproj
+++ b/vsmac-cli/vsmac-cli.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>vsmac</AssemblyName>
-    <Version>0.2</Version>
+    <Version>0.3</Version>
     <RootNamespace>VSMacLocator</RootNamespace>
     <Nullable>enable</Nullable>
     <PackAsTool>True</PackAsTool>


### PR DESCRIPTION
The bin dir has changed for VSMac 17, this change adjusts the path to the new location.